### PR TITLE
Agregando services

### DIFF
--- a/src/controllers/comandaController.js
+++ b/src/controllers/comandaController.js
@@ -3,6 +3,7 @@ import {ComandaRepository} from "../repositories/comandaRepository.js";
 import {Menu} from "../repositories/menu.js";
 import {PlatoInvalido} from "../excepciones/platos.js";
 import {ComandaInvalida} from "../excepciones/comandas.js";
+import {ComandaService} from "../services/comandaService.js";
 
 const aComandaRest = (comanda) => {
   return {
@@ -52,14 +53,14 @@ export const ComandaController = {
     try {
       const idComanda = parseInt(req.params.id);
       const comanda = ComandaRepository.obtenerPorId(idComanda);
-      const datosPlato = req.body;
+      const datosPlato = req.body
       const nuevoPlato = new PlatoPedido(
         Menu.obtenerPlatoPorId(datosPlato.idPlato),
         datosPlato.cantidad,
         datosPlato.notas
       )
       comanda.agregarPlato(nuevoPlato)
-      res.status(200).json(aComandaRest(ComandaRepository.actualizarComanda(idComanda, comanda)))
+      res.status(200).json(aComandaRest(ComandaRepository.guardarComanda(idComanda, comanda)))
     } catch (error) {
       console.error(error)
       if (error instanceof ComandaInvalida) {
@@ -75,7 +76,7 @@ export const ComandaController = {
       const idComanda = parseInt(req.params.id);
       const comanda = ComandaRepository.obtenerPorId(idComanda);
       comanda.marcarBebidasListas(req.body.bebidasListas)
-      res.status(200).json(aComandaRest(ComandaRepository.actualizarComanda(idComanda, comanda)))
+      res.status(200).json(aComandaRest(ComandaRepository.guardarComanda(idComanda, comanda)))
     } catch (error) {
       console.error(error)
       if (error instanceof ComandaInvalida) {
@@ -101,7 +102,7 @@ export const ComandaController = {
       if(actualizacionesPlato.estaListo){
         comanda.marcarListo(ordenPlato, actualizacionesPlato.estaListo)
       }
-      res.status(200).json(aComandaRest(ComandaRepository.actualizarComanda(idComanda, comanda)))
+      res.status(200).json(aComandaRest(ComandaRepository.guardarComanda(idComanda, comanda)))
     } catch (error) {
       console.error(error)
       if (error instanceof ComandaInvalida) {

--- a/src/controllers/comandaController.js
+++ b/src/controllers/comandaController.js
@@ -21,23 +21,13 @@ const aComandaRest = (comanda) => {
   }
 };
 
-const deComandaRest = (comandaRest) => {
-  //TODO realizar validaciones si corresponde
-};
-
 export const ComandaController = {
 
   crearComanda(req, res) {
     try {
       const mesa = req.body.mesa;
-      const platosPedidos = req.body.platos.map(p =>
-        new PlatoPedido(
-          Menu.obtenerPlatoPorId(p.idPlato),
-          p.cantidad,
-          p.notas
-        )
-      );
-      const comanda = ComandaRepository.agregarComanda(new Comanda(mesa, platosPedidos))
+      const platos = req.body.platos;
+      const comanda = ComandaService.crearComanda(mesa, platos)
       res.status(201).json(aComandaRest(comanda))
     } catch (error) {
       console.error(error)
@@ -52,14 +42,7 @@ export const ComandaController = {
   agregarPlatosComanda(req, res) {
     try {
       const idComanda = parseInt(req.params.id);
-      const comanda = ComandaRepository.obtenerPorId(idComanda);
-      const datosPlato = req.body
-      const nuevoPlato = new PlatoPedido(
-        Menu.obtenerPlatoPorId(datosPlato.idPlato),
-        datosPlato.cantidad,
-        datosPlato.notas
-      )
-      comanda.agregarPlato(nuevoPlato)
+      const comanda = ComandaService.agregarPlatoComanda(idComanda, req.body);
       res.status(200).json(aComandaRest(ComandaRepository.guardarComanda(idComanda, comanda)))
     } catch (error) {
       console.error(error)
@@ -74,8 +57,7 @@ export const ComandaController = {
   actualizarBebidasComanda(req, res) {
     try {
       const idComanda = parseInt(req.params.id);
-      const comanda = ComandaRepository.obtenerPorId(idComanda);
-      comanda.marcarBebidasListas(req.body.bebidasListas)
+      const comanda = ComandaService.actualizarBebidasComanda(idComanda)
       res.status(200).json(aComandaRest(ComandaRepository.guardarComanda(idComanda, comanda)))
     } catch (error) {
       console.error(error)
@@ -90,19 +72,9 @@ export const ComandaController = {
   actualizarPlatoComanda(req, res) {
     try {
       const idComanda = parseInt(req.params.id);
-      const comanda = ComandaRepository.obtenerPorId(idComanda);
       const actualizacionesPlato = req.body;
-      const ordenPlato = req.params.ordenPlato;
-      if(actualizacionesPlato.notas) {
-        comanda.agregarNotas(ordenPlato, actualizacionesPlato.notas)
-      }
-      if(actualizacionesPlato.cantidad){
-        comanda.asignarCantidad(ordenPlato, actualizacionesPlato.cantidad)
-      }
-      if(actualizacionesPlato.estaListo){
-        comanda.marcarListo(ordenPlato, actualizacionesPlato.estaListo)
-      }
-      res.status(200).json(aComandaRest(ComandaRepository.guardarComanda(idComanda, comanda)))
+      const comanda = ComandaService.actualizarPlatoComanda(idComanda, actualizacionesPlato);
+      res.status(200).json(aComandaRest(comanda))
     } catch (error) {
       console.error(error)
       if (error instanceof ComandaInvalida) {

--- a/src/controllers/platosController.js
+++ b/src/controllers/platosController.js
@@ -1,6 +1,7 @@
 import {Categoria, Plato} from "../domain/dominio.js";
 import {Menu} from "../repositories/menu.js";
 import {PlatoInexistente, PlatoInvalido} from "../excepciones/platos.js";
+import {PlatosService} from "../services/platosService.js";
 
 const aPlatoRest = (datosDelPlato) => {
   return {
@@ -27,7 +28,7 @@ export const PlatosController = {
 
   crearPlato(req, res){
     try{
-      const plato = Menu.agregarPlato(new Plato(dePlatoRest(req.body)))
+      const plato = PlatosService.agregarPlato(dePlatoRest(req.body))
       res.status(201).json(aPlatoRest(plato))
     } catch(error){
       console.error(error)
@@ -41,10 +42,9 @@ export const PlatosController = {
 
   actualizarPlato(req, res){
     try{
-      const plato = Menu.obtenerPlatoPorId(parseInt(req.params.id))
+      const platoId = parseInt(req.params.id);
       const actualizaciones = dePlatoRest(req.body)
-      plato.actualizar(actualizaciones)
-      const platoActualizado = Menu.guardarPlato(plato)
+      const platoActualizado = PlatosService.actualizarPlato(platoId, actualizaciones)
       res.status(200).json(aPlatoRest(platoActualizado))
     } catch(error){
       console.error(error)

--- a/src/controllers/platosController.js
+++ b/src/controllers/platosController.js
@@ -41,8 +41,10 @@ export const PlatosController = {
 
   actualizarPlato(req, res){
     try{
-      const plato = dePlatoRest(req.body)
-      const platoActualizado = Menu.actualizarPlatoPorId(parseInt(req.params.id), plato)
+      const plato = Menu.obtenerPlatoPorId(parseInt(req.params.id))
+      const actualizaciones = dePlatoRest(req.body)
+      plato.actualizar(actualizaciones)
+      const platoActualizado = Menu.guardarPlato(plato)
       res.status(200).json(aPlatoRest(platoActualizado))
     } catch(error){
       console.error(error)
@@ -60,7 +62,7 @@ export const PlatosController = {
 
   marcarPlatoDisponible(req, res){
     try{
-      const plato = Menu.actualizarPlatoPorId(parseInt(req.params.id), dePlatoRest(req.body))
+      const plato = Menu.guardarPlato(parseInt(req.params.id), dePlatoRest(req.body))
       res.status(200).json(aPlatoRest(plato))
     } catch(error){
       console.error(error)

--- a/src/domain/dominio.js
+++ b/src/domain/dominio.js
@@ -2,6 +2,7 @@ import {negate, remove} from "lodash-es";
 import {isEmpty, max, maxBy, values} from "lodash-es";
 import {sumBy} from "lodash-es";
 import {PlatoInvalido} from "../excepciones/platos.js";
+import {reemplazarValoresNoNulos} from "../utils/object-utils.js";
 
 export class Plato {
   id;
@@ -22,6 +23,12 @@ export class Plato {
     if ([precio, nombre, categoria].some(v => !v)) {
       throw new PlatoInvalido(`El plato necesita precio, nombre y categoria, se recibio nombre: ${nombre}, categoria: ${categoria}, precio: ${precio}` );
     }
+  }
+
+  actualizar(actualizacionesParciales){
+    //En vez de hacer metodos separados y muchos ifs como en la comanda usamos un poco de magia
+    // con esta funcion definida en utils para hacerlo más conciso
+    reemplazarValoresNoNulos(this,actualizacionesParciales)
   }
 
   esDeCategoria(categoria) {

--- a/src/domain/dominio.js
+++ b/src/domain/dominio.js
@@ -26,8 +26,6 @@ export class Plato {
   }
 
   actualizar(actualizacionesParciales){
-    //En vez de hacer metodos separados y muchos ifs como en la comanda usamos un poco de magia
-    // con esta funcion definida en utils para hacerlo más conciso
     reemplazarValoresNoNulos(this,actualizacionesParciales)
   }
 

--- a/src/repositories/comandaRepository.js
+++ b/src/repositories/comandaRepository.js
@@ -18,7 +18,11 @@ export const ComandaRepository = {
   },
 
   obtenerPorId(id){
-    return this.comandas.find(c => c.id === id);
+    const comanda = this.comandas.find(c => c.id === id);
+    if(!comanda){
+      throw new ComandaInexistente(id)
+    }
+    return comanda;
   },
 
   listarPorFlags(platosPendientes, bebidasPendientes){
@@ -29,11 +33,7 @@ export const ComandaRepository = {
       );
   },
 
-  actualizarComanda(id, comandaActualizada){
-    const comandaAActualizar = this.obtenerPorId(id);
-    if(!comandaAActualizar){
-      throw new ComandaInexistente(id)
-    }
+  guardarComanda(id, comandaActualizada){
     remove(this.comandas, c=> c.id === id)
     this.comandas.push(comandaActualizada);
     return comandaActualizada;

--- a/src/repositories/menu.js
+++ b/src/repositories/menu.js
@@ -16,16 +16,17 @@ export const Menu = {
   },
 
   obtenerPlatoPorId(id){
-    return this.platos.find(p => p.id === id);
-  },
-
-  actualizarPlatoPorId(id, actualizacionesDelPlato){
-    const platoAActualizar = this.obtenerPlatoPorId(id);
-    if(!platoAActualizar){
+    const plato = this.platos.find(p => p.id === id);
+    if(!plato){
       throw new PlatoInexistente(id)
     }
-    reemplazarValoresNoNulos(platoAActualizar,actualizacionesDelPlato)
-    return platoAActualizar;
+    return plato;
+  },
+
+  guardarPlato(platoActualizado){
+    remove(this.platos, p=> p.id === platoActualizado.id)
+    this.platos.push(platoActualizado);
+    return platoActualizado
   },
 
   borrar(plato){

--- a/src/services/comandaService.js
+++ b/src/services/comandaService.js
@@ -1,8 +1,20 @@
 import {ComandaRepository} from "../repositories/comandaRepository.js";
-import {PlatoPedido} from "../domain/dominio.js";
+import {Comanda, PlatoPedido} from "../domain/dominio.js";
 import {Menu} from "../repositories/menu.js";
 
 export const ComandaService = {
+
+  crearComanda(mesa, platos) {
+    const platosPedidos = platos.map(p =>
+      new PlatoPedido(
+        Menu.obtenerPlatoPorId(p.idPlato),
+        p.cantidad,
+        p.notas
+      )
+    );
+    return ComandaRepository.agregarComanda(new Comanda(mesa, platosPedidos))
+  },
+
   agregarPlatoComanda(idComanda, datosPlato) {
     const comanda = ComandaRepository.obtenerPorId(idComanda);
     const nuevoPlato = new PlatoPedido(
@@ -12,5 +24,27 @@ export const ComandaService = {
     )
     comanda.agregarPlato(nuevoPlato)
     return comanda;
+  },
+
+  actualizarBebidasComanda(idComanda){
+    const comanda = ComandaRepository.obtenerPorId(idComanda);
+    comanda.marcarBebidasListas(req.body.bebidasListas)
+    return comanda;
+  },
+
+  actualizarPlatoComanda(idComanda, actualizacionesPlato){
+    const comanda = ComandaRepository.obtenerPorId(idComanda);
+    const ordenPlato = req.params.ordenPlato;
+    if(actualizacionesPlato.notas) {
+      comanda.agregarNotas(ordenPlato, actualizacionesPlato.notas)
+    }
+    if(actualizacionesPlato.cantidad){
+      comanda.asignarCantidad(ordenPlato, actualizacionesPlato.cantidad)
+    }
+    if(actualizacionesPlato.estaListo){
+      comanda.marcarListo(ordenPlato, actualizacionesPlato.estaListo)
+    }
+    ComandaRepository.guardarComanda(idComanda, comanda);
+    return comanda
   }
 }

--- a/src/services/comandaService.js
+++ b/src/services/comandaService.js
@@ -1,0 +1,16 @@
+import {ComandaRepository} from "../repositories/comandaRepository.js";
+import {PlatoPedido} from "../domain/dominio.js";
+import {Menu} from "../repositories/menu.js";
+
+export const ComandaService = {
+  agregarPlatoComanda(idComanda, datosPlato) {
+    const comanda = ComandaRepository.obtenerPorId(idComanda);
+    const nuevoPlato = new PlatoPedido(
+      Menu.obtenerPlatoPorId(datosPlato.idPlato),
+      datosPlato.cantidad,
+      datosPlato.notas
+    )
+    comanda.agregarPlato(nuevoPlato)
+    return comanda;
+  }
+}

--- a/src/services/platosService.js
+++ b/src/services/platosService.js
@@ -1,0 +1,16 @@
+import {ComandaRepository} from "../repositories/comandaRepository.js";
+import {Comanda, Plato, PlatoPedido} from "../domain/dominio.js";
+import {Menu} from "../repositories/menu.js";
+
+export const PlatosService = {
+
+  agregarPlato(datosPlato){
+    return Menu.agregarPlato(new Plato(datosPlato))
+  },
+
+  actualizarPlato(platoId, actualizaciones) {
+    const plato = Menu.obtenerPlatoPorId(platoId)
+    plato.actualizar(actualizaciones)
+    return  Menu.guardarPlato(plato)
+  }
+}


### PR DESCRIPTION
Notas:

- Los métodos `buscarComanda` y `verComanda` de `ComandaController` no tenían suficiente lógica adicional como -ara que se justificara agregar el service en el medio, ya que habrian terminado siendo pasamanos. Además, si pensamos en las interfaces (es decir, que datos consumen y devuelven) de hipotéticos `buscarComanda` y `verComanda` a nivel de service, podemos notar que consumen y devuelven valores primitivos simples o la Comanda en sí, que no generan un acoplamiento adicional innecesario entre el Controller y el Service. 

- El `PlatoService` tiene bastante poca lógica y sólo dos métodos, y la mayoría de las operaciones del Controller no lo utilizan. En este caso sería también válido argumentar que, por simplicidad, no se justifica hacer este Service por el momento.